### PR TITLE
Running build_fast.sh provides a 1-step build process

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.2)
       railties (>= 3.2.16)
-    json (1.8.1)
+    json (1.8.3)
     kaminari (0.16.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -343,4 +343,4 @@ RUBY VERSION
    ruby 2.2.0p0
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -254,8 +254,13 @@ for detailed instructions on installation. You can also post a question to the
 
 ## Usage
 
+* Rails Server
 ```
-rails server
+sh server.sh
+```
+* Testing the App (after running build_fast.sh)
+```
+sh test_app.sh
 ```
 
 ## Importing More Trees

--- a/README.md
+++ b/README.md
@@ -27,7 +27,87 @@ Open Twin Cities is dedicated to a harassment-free community for everyone. Be
 kind to one another. Do not insult or put down other community members. Behave 
 civilly.
 
-## Installation
+## Installation (Easy Way)
+The easy way of setting up Adopt-a-Tree is by using Docker to set up a virtual
+environment on your computer.
+
+### Windows Users
+Installing Ruby on Rails directly in Windows is extremely difficult, and very
+few people know how to do it.  It's best to install [VirtualBox](https://www.virtualbox.org/)
+and create a Linux virtual machine for your Ruby on Rails installation.
+Once you have done this, you can follow the instructions below for setting
+up Adopt-a-Tree in the Linux environment and bypass the need to learn the
+Windows way.
+
+### Install Git
+Install [Git](http://www.git-scm.com/) on your computer.  If you are using Linux,
+just use your routine package manager (such as Apt-Get for Debian and Ubuntu) to
+install Git.  If you are using OS X, just download Git from the [Git](http://www.git-scm.com/)
+web site and follow the normal software installation procedure.
+
+### Install Docker
+Install [Docker](https://www.docker.com/) on your computer.  If you have a
+64-bit host system (whether OS X or Linux), go to the [Docker](https://www.docker.com/)
+web site and follow the instructions.  If you have a 32-bit Linux host, go to
+[https://github.com/jhsu802701/docker-32bit-debian-jessie-install](https://github.com/jhsu802701/docker-32bit-debian-jessie-install)
+and follow the instructions.
+
+### Starting Docker
+* Create the directory OpenTwinCities on your computer.
+* Use the cd command to enter the OpenTwinCities directory, and enter the following commands:
+```
+git clone https://github.com/OpenTwinCities/docker-debian-jessie.git
+cd docker-debian-jessie
+sh rbenv-adoptatree.sh # Use 32rbenv-adoptatree.sh instead if using a 32-bit system
+cd rbenv-adoptatree
+sh download_new_image.sh
+```
+* After the Docker image has been downloaded, you will be in your Docker container.
+Note that the contents of the shared directory are accessible through your Docker
+container AND through your host system.  You can enter commands in your Docker container
+and edit files in the shared directory through your preferred editor on your host system.
+* OPTIONAL: Run the test scripts in the shared directory to set up basic starter
+Rails apps.  These are the sanity checks used for making sure that the development
+environment in the Docker container is working properly.
+  
+### Starting Adopt-a-Tree
+* Go to the /home/winner/shared directory, and enter the following commands:
+```
+git clone https://github.com/OpenTwinCities/adopt-a-tree.git
+cd adopt-a-tree
+sh build_fast.sh
+```
+* The build_fast.sh script installs the gems, configures the PostgreSQL database,
+and runs the tests.  This process takes just a few minutes.  If all goes well, all
+of the tests will pass.
+* After you have set up Adopt-a-Tree, you are ready to start working on the project.
+Use the tmux command to open any additional windows you need for simultaneous tasks, 
+such as running the local server and running the Rails sandbox.  Press "Ctrl-B" and 
+then "c" to create a new tmux window.  Enter "Ctrl-B" and then "p" to switch to the 
+previous tmux window.  Press "Ctrl-B" and then "n" to switch to the next tmux window.
+To get rid of a tmux window, terminate any tasks running within it, and enter the 
+command "exit".
+
+### Exiting the Docker Container
+* In the Docker container, close all extra tmux windows.  After you have done this,
+enter "exit" again to leave tmux.  Then enter "exit" one more time to exit the
+Docker container.
+* To re-enter the Docker container, run the resume.sh script.
+
+### Resetting the Docker Container
+* Follow the above procedure for exiting the Docker container.
+* To reset as well as re-enter the Docker container, run the reset.sh script.
+This returns the Docker container to the original conditions provided by the
+Docker image.
+
+### Updating the Docker Image
+* Follow the above procedures for exiting the Docker container.
+* Use the download_new_image.sh script to erase the current Docker image and
+download the latest version to replace it.
+
+## Installation (Difficult Way)
+
+The difficult way is setting Adopt-a-Tree directly on your computer's host OS.
 
 ### System Dependencies
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Docker container.
 * To reset as well as re-enter the Docker container, run the reset.sh script.
 This returns the Docker container to the original conditions provided by the
 Docker image.
+* To set up Adopt-a-Tree in the rebuilt Docker container, use the build_fast.sh
+script again.
 
 ### Updating the Docker Image
 * Follow the above procedures for exiting the Docker container.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ web site and follow the instructions.  If you have a 32-bit Linux host, go to
 [https://github.com/jhsu802701/docker-32bit-debian-jessie-install](https://github.com/jhsu802701/docker-32bit-debian-jessie-install)
 and follow the instructions.
 
+### Switching from the Dash shell to Bash shell
+* The scripts in the Docker repository (https://github.com/OpenTwinCities/docker-debian-jessie) used for accessing Docker require the use of Bash.  (The "sed" commands used in the setup.sh script do not work properly in Dash.)
+* To check your default shell, enter the command "ls -l /bin/sh".
+* To change your default shell to Bash, enter the following commands:
+```
+sudo rm /bin/sh
+sudo ln -s /bin/bash /bin/sh
+```
+
 ### Starting Docker
 * Create the directory OpenTwinCities on your computer.
 * Use the cd command to enter the OpenTwinCities directory, and enter the following commands:

--- a/build_fast.sh
+++ b/build_fast.sh
@@ -6,24 +6,6 @@
 # You can reinstall Ruby on Rails in seconds instead of hours.
 # You can have everything working on your machine in minutes instead of hours or days.
 
-# ENTERING THE CUSTOMIZED DOCKER IMAGE:
-# 1.  Have Docker or Docker Machine installed on your host OS.
-# 2.  Enter the following commands:
-#     git clone https://github.com/OpenTwinCities/docker-debian-jessie
-#     sh rbenv-adoptatree.sh # Use 32rbenv-adoptatree.sh instead if using a 32-bit system.
-#     cd rbenv-adoptatree
-#     sh download_new_image.sh
-# 3.  If your Internet connection is reasonably fast, you will be in the Docker
-#     development environment, where you can get started on this project.
-
-# GETTING STARTED
-# 1.  Use tmux for simultaneous operations
-# 2.  Enter the following commands:
-#     git clone https://github.com/OpenTwinCities/adopt-a-tree.git
-#     cd adopt-a-tree
-# 3.  Enter the command "sh build_fast.sh".  In a few minutes, your project should be
-#     fully set up, and all tests should pass.
-
 PG_VERSION="$(ls /etc/postgresql)"
 PG_HBA="/etc/postgresql/$PG_VERSION/main/pg_hba.conf"
 

--- a/build_fast.sh
+++ b/build_fast.sh
@@ -73,10 +73,6 @@ echo '-------------------------------'
 echo 'bundle exec rake db:schema:load'
 bundle exec rake db:schema:load
 
-echo '-------------------------------'
-echo 'bundle exec rake db:schema:load'
-bundle exec rake db:schema:load
-
 echo '------------------------'
 echo 'bundle exec rake db:seed'
 bundle exec rake db:seed

--- a/build_fast.sh
+++ b/build_fast.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# After you use the reset.sh script to return the Docker container to a
+# fresh Ruby on Rails environment and use the "git clone" command to
+# download this project's source code, running this script sets up this
+# project AND runs all tests.
+
+# Resetting the Docker container to its original state AND running this
+# script ensures that you are on top of all dependencies and can avoid
+# being stopped in your tracks by the infamous "works on my machine"
+# problem.
+
+# This is Joel Spolsky's one-step build process at work.
+
+PG_VERSION="$(ls /etc/postgresql)"
+PG_HBA="/etc/postgresql/$PG_VERSION/main/pg_hba.conf"
+
+# Change the settings in the pg_hba.conf file
+# Use the settings from the Travis environment with these two differences:
+# 1.  Full access to the adopta user
+# 2.  Full access to 0.0.0.0 (localhost) for pgAdmin host machine access
+echo '-------------------'
+echo "Configuring $PG_HBA"
+
+sudo bash -c "echo '# TYPE  DATABASE        USER            ADDRESS                 METHOD' > $PG_HBA"
+sudo bash -c "echo '' >> $PG_HBA"
+sudo bash -c "echo '# Allow adopta user to connect to database without password' >> $PG_HBA"
+sudo bash -c "echo 'local   all             adopta                                  trust' >> $PG_HBA"
+sudo bash -c "echo '' >> $PG_HBA"
+sudo bash -c "echo '# Allow postgres user to connect to database without password' >> $PG_HBA"
+sudo bash -c "echo 'local   all             postgres                                trust' >> $PG_HBA"
+sudo bash -c "echo '' >> $PG_HBA"
+sudo bash -c "echo 'local   all             all                                     trust' >> $PG_HBA"
+sudo bash -c "echo '' >> $PG_HBA"
+sudo bash -c "echo '# IPv4 local connections:' >> $PG_HBA"
+sudo bash -c "echo 'host    all             all             0.0.0.0/0               trust' >> $PG_HBA"
+sudo bash -c "echo '' >> $PG_HBA"
+sudo bash -c "echo '# IPv6 local connections:' >> $PG_HBA"
+sudo bash -c "echo 'host    all             all             ::1/128                 trust' >> $PG_HBA"
+
+echo '-------------------------------'
+echo 'sudo service postgresql restart'
+sudo service postgresql restart
+wait
+
+export TEST_DATABASE_USERNAME=postgres
+
+echo '------------------'
+echo 'gem update bundler'
+gem update bundler
+
+echo '--------------'
+echo 'bundle install'
+bundle install
+
+echo '-------------------------------------'
+echo 'sudo -u postgres createuser -d adopta'
+sudo -u postgres createuser -d adopta
+
+echo '-------------------------------------------------'
+echo "'create database adopta_development;' -U postgres"
+psql -c 'create database adopta_development;' -U postgres
+
+echo '--------------------------------------------------'
+echo "psql -c 'create database adopta_test;' -U postgres"
+psql -c 'create database adopta_test;' -U postgres
+
+echo '----------------------------------------------'
+echo 'psql -U postgres -c "create extension postgis"'
+psql -U postgres -c "create extension postgis"
+
+echo '-------------------------------'
+echo 'bundle exec rake db:schema:load'
+bundle exec rake db:schema:load
+
+echo '-------------------------------'
+echo 'bundle exec rake db:schema:load'
+bundle exec rake db:schema:load
+
+echo '------------------------'
+echo 'bundle exec rake db:seed'
+bundle exec rake db:seed
+
+echo '----------------'
+echo 'bundle exec rake'
+bundle exec rake

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,10 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # From http://mailcatcher.me/
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: 'localhost', port: 1025 }
 end

--- a/mailcatcher.sh
+++ b/mailcatcher.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+gem install mailcatcher
+mailcatcher --ip 0.0.0.0
+echo 'View mail at http://localhost:<port number>/'
+echo 'If you are developing this app in the host environment, the port number is 1080.'
+echo 'If you are using Docker or Vagrant, the port number may be something else.'
+echo 'If you are using Docker Machine, replace "localhost" with the appropriate numerical IP address (probably 192.168.99.100).'
+# Send mail through smtp://localhost:1025

--- a/server.sh
+++ b/server.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo '-----------------------------'
+echo 'sudo service postgresql start'
+sudo service postgresql start
+
+echo 'View page at http://localhost:3000/'
+echo 'If you are using Docker or Vagrant,'
+echo 'the port number may be something else.'
+echo 'If you are using Docker Machine,'
+echo 'replace "localhost" with a numerical' 
+echo 'IP address (probably 192.168.99.100).'
+
+echo '-----------------------'
+echo 'rails server -b 0.0.0.0'
+rails server -b 0.0.0.0

--- a/spec/features/adoption_form_spec.rb
+++ b/spec/features/adoption_form_spec.rb
@@ -27,7 +27,7 @@ describe 'Adoption Form', js: true do
     end
 
     it 'Opens the "Adopt this Tree" form' do
-      expect(page).to have_selector '#adoption_form'
+      expect(page).to have_selector('#adoption_form', wait: 10)
       expect(page).to have_content 'Adopt this Tree'
     end
 
@@ -38,17 +38,17 @@ describe 'Adoption Form', js: true do
 
       it 'Displays the "Thank you" message' do
         expect(page).to_not have_content 'Adopt this Tree'
-        expect(page).to have_content 'Thank you for adopting this tree!'
+        expect(page).to have_content('Thank you for adopting this tree!', wait: 10)
       end
 
       it 'Displays social media links' do
-        expect(page).to have_css("img[src*='FB-f-Logo__blue_29.png']")
+        expect(page).to have_css("img[src*='FB-f-Logo__blue_29.png']", wait: 10)
         expect(page).to have_css("img[src*='TwitterLogo_55acee.png']")
       end
 
       it 'Displays the "Edit Profile" view in the sidebar' do
         within '.sidebar' do
-          expect(page).to have_selector 'form#edit_form.edit_user'
+          expect(page).to have_selector('form#edit_form.edit_user', wait: 10)
         end
       end
     end

--- a/spec/features/adoption_form_spec.rb
+++ b/spec/features/adoption_form_spec.rb
@@ -27,7 +27,7 @@ describe 'Adoption Form', js: true do
     end
 
     it 'Opens the "Adopt this Tree" form' do
-      expect(page).to have_selector('#adoption_form', wait: 10)
+      expect(page).to have_selector('#adoption_form', wait: 20)
       expect(page).to have_content 'Adopt this Tree'
     end
 
@@ -38,17 +38,17 @@ describe 'Adoption Form', js: true do
 
       it 'Displays the "Thank you" message' do
         expect(page).to_not have_content 'Adopt this Tree'
-        expect(page).to have_content('Thank you for adopting this tree!', wait: 10)
+        expect(page).to have_content('Thank you for adopting this tree!', wait: 20)
       end
 
       it 'Displays social media links' do
-        expect(page).to have_css("img[src*='FB-f-Logo__blue_29.png']", wait: 10)
+        expect(page).to have_css("img[src*='FB-f-Logo__blue_29.png']", wait: 20)
         expect(page).to have_css("img[src*='TwitterLogo_55acee.png']")
       end
 
       it 'Displays the "Edit Profile" view in the sidebar' do
         within '.sidebar' do
-          expect(page).to have_selector('form#edit_form.edit_user', wait: 10)
+          expect(page).to have_selector('form#edit_form.edit_user', wait: 20)
         end
       end
     end

--- a/test_app.sh
+++ b/test_app.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script runs the "bundle install" command, database migrations,
+# and tests.  This is a shortened version of the build_fast.sh script.
+
+# Do NOT use this script until you have set up this project with the build_fast.sh script.
+
+echo '-------------------------------'
+echo 'sudo service postgresql restart'
+sudo service postgresql restart
+wait
+
+export TEST_DATABASE_USERNAME=postgres
+
+echo '--------------'
+echo 'bundle install'
+bundle install
+
+echo '---------------------------'
+echo 'bundle exec rake db:migrate'
+bundle exec rake db:migrate
+
+echo '----------------'
+echo 'bundle exec rake'
+bundle exec rake


### PR DESCRIPTION
* The build_fast.sh script sets up everything and runs tests, which all pass.
* build_fast.sh script is based on the settings and commands in the Travis CI environment.
* Selected Capybara tests in spec/features/adoption_form_spec.rb are allowed up to a 20-second wait time to eliminate intermittent test failures.
* Creating the PostgreSQL extension postgis requires the packages postgresql-9.4-postgis-2.1 and postgresql-9.4-postgis-scripts (now provided in the custom Adopt-a-Tree Docker image).
* json gem upgraded, because "bundle install" refused to install version 1.8.1
* The mailcatcher.sh script combined with the revised config/environments/development.rb setup allows you to simulate the user experience with emails.
* The server.sh script starts up the local server and makes the web pages of this app available on the host system.