### PR TITLE
Fixing Google Analytics implementation

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,14 +12,14 @@
     = javascript_include_tag "//ajax.googleapis.com/ajax/libs/jquery/1.8/jquery.min.js"
     = javascript_include_tag "//ajax.googleapis.com/ajax/libs/jqueryui/1.8/jquery-ui.min.js"
     = javascript_include_tag "application"
-    - if Rails.env.production? && AppConfig.google_analytics.id.present?
+    - if (Rails.env.production? || Rails.env.stage?) && AppConfig.google_analytics.id.present?
       %script{:type => "text/javascript"}
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', #{AppConfig.google_analytics.id}, #{AppConfig.google_analytics.id});
+        ga('create', '#{AppConfig.google_analytics.id}', '#{AppConfig.google_analytics.domain || "auto"}');
         ga('send', 'pageview');
     = stylesheet_link_tag "application"
   %body


### PR DESCRIPTION
Wrapping Google Analytics properties in quotes to be string literals
Passing along the correct config property for Google Analytics domain
Defaulting Google Analytics Domain to be 'auto'
Allowing Google Analytics in stage and production
Fixes #49