### PR TITLE
Removed init.sql (not necessary)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - db_data:/var/lib/postgresql/data
-      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - "15432:5432"
 

--- a/init.sql
+++ b/init.sql
@@ -1,1 +1,0 @@
-CREATE ROLE adopta;


### PR DESCRIPTION
The init.sql script is not necessary for setting up the Docker environment.